### PR TITLE
fix: remove hardcoded A2A tokens and Tailscale IP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,11 @@ ANTHROPIC_API_KEY=
 GROQ_API_KEY=
 DEEPSEEK_API_KEY=
 GOOGLE_API_KEY=
+
+# A2A Federation (intel_exchange.py)
+# Set these to connect to your Glorft and Mordecai A2A endpoints.
+# Generate tokens with: openssl rand -base64 24 | tr -d '=+/' | cut -c1-32
+GLORFT_A2A_URL=http://localhost:9092/a2a/tasks/send
+GLORFT_A2A_TOKEN=
+MORDECAI_A2A_URL=http://localhost:9092/a2a/tasks/send
+MORDECAI_A2A_TOKEN=

--- a/intel_exchange.py
+++ b/intel_exchange.py
@@ -12,13 +12,13 @@ import urllib.request
 import urllib.error
 from datetime import datetime, timezone
 
-# Glorft/DROX A2A config
-GLORFT_URL = "http://100.106.81.19:9092/a2a/tasks/send"
-GLORFT_TOKEN = "An9U8IkH28WoeVDTs3zFrhEzBlrGo1IM"
+# Glorft/DROX A2A config — loaded from environment variables
+GLORFT_URL = os.getenv("GLORFT_A2A_URL", "http://localhost:9092/a2a/tasks/send")
+GLORFT_TOKEN = os.getenv("GLORFT_A2A_TOKEN", "")
 
 # Mordecai A2A config (for receiving)
-MORDECAI_URL = "http://localhost:9092/a2a/tasks/send"
-MORDECAI_TOKEN = "6OFUpWpl5sQZ8KUxDIJ0Kzxykoj4I"
+MORDECAI_URL = os.getenv("MORDECAI_A2A_URL", "http://localhost:9092/a2a/tasks/send")
+MORDECAI_TOKEN = os.getenv("MORDECAI_A2A_TOKEN", "")
 
 
 def build_intel_packet(data_file: str, packet_type: str = "daily-brief") -> dict:


### PR DESCRIPTION
Fixes #1

## Changes

- **`intel_exchange.py`**: Replace hardcoded `GLORFT_TOKEN`, `GLORFT_URL`, `MORDECAI_TOKEN`, and `MORDECAI_URL` constants with `os.getenv()` calls. Safe fallback to `localhost:9092` when env vars are unset.
- **`.env.example`**: Add `GLORFT_A2A_URL`, `GLORFT_A2A_TOKEN`, `MORDECAI_A2A_URL`, `MORDECAI_A2A_TOKEN` with a token generation command in the comments.

## Token rotation

The previously hardcoded tokens are in git history and should be considered compromised. Rotate them with:

```bash
openssl rand -base64 24 | tr -d '=+/' | cut -c1-32
```

Update `~/.openclaw/a2a-config.json` on the Glorft host and the peer config on the Mordecai host accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)